### PR TITLE
Fix serialization of module paths

### DIFF
--- a/src/build_loader.js
+++ b/src/build_loader.js
@@ -30,7 +30,7 @@ var serialize = function(modules, options) {
   modules.forEach(function (module) {
     if (module.noflo && module.noflo.loader) {
       var loaderPath = path.resolve(options.baseDir, module.base, module.noflo.loader);
-      loaders.push(indent + "require('" + loaderPath + "')");
+      loaders.push(indent + "require(" + JSON.stringify(loaderPath) + ")");
     }
     if (!module.components) {
       return;
@@ -38,7 +38,7 @@ var serialize = function(modules, options) {
     module.components.forEach(function (component) {
       var fullname = module.name ? module.name + "/" + component.name : component.name;
       var componentPath = path.resolve(options.baseDir, component.path);
-      lines.push(indent + "'" + fullname + "': require('" + componentPath + "')");
+      lines.push(indent + "'" + fullname + "': require(" + JSON.stringify(componentPath) + ")");
     });
   });
   var contents = {


### PR DESCRIPTION
This PR fixes grunt build task of noflo-ui on Windows.

The problem is that module paths are stringified by concatenation. The `\\` in them becomes just `\` after insertion into templated js file, which breaks paths on Windows.

The fix is to use `JSON.stringify` to escape everything in a path string correctly. Other platforms will not be affected by this.