### PR TITLE
getSource: return original, non-transpiled sources for debug builds

### DIFF
--- a/spec/SmokeTest.js
+++ b/spec/SmokeTest.js
@@ -124,7 +124,7 @@ describe('A browser-built module', function () {
           chai.expect(c.library).to.equal('bar');
           chai.expect(c.name).to.equal('AddOne');
           chai.expect(c.language).to.equal('javascript');
-          chai.expect(c.code).to.contain('noflo.Component');
+          chai.expect(c.code).to.equal(source);
           done();
         });
       });

--- a/spec/SmokeTest.js
+++ b/spec/SmokeTest.js
@@ -38,6 +38,22 @@ describe('A browser-built module', function () {
       ins.disconnect();
     });
     describe('getSource', function () {
+      var repeatSource = null;
+      before(function (done) {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState !== 4) {
+            return;
+          }
+          if (xhr.status !== 200) {
+            return done(new Error("Responded with " + xhr.status));
+          }
+          repeatSource = xhr.responseText;
+          done();
+        }
+        xhr.open('GET', './fixtures/node_modules/noflo-core/components/Repeat.coffee', true);
+        xhr.send(null);
+      });
       it('should be able to read sources for elementary component', function (done) {
         var loader = new noflo.ComponentLoader('');
         loader.getSource('core/Repeat', function (err, c) {
@@ -46,8 +62,8 @@ describe('A browser-built module', function () {
           }
           chai.expect(c.library).to.equal('core');
           chai.expect(c.name).to.equal('Repeat');
-          chai.expect(c.language).to.equal('javascript');
-          chai.expect(c.code).to.contain('noflo.Component');
+          chai.expect(c.language).to.equal('coffeescript');
+          chai.expect(c.code).to.equal(repeatSource);
           done();
         });
       });

--- a/src/build_loader.js
+++ b/src/build_loader.js
@@ -29,7 +29,7 @@ var serialize = function(modules, options, callback) {
   var loaders = [];
   var components = [];
   var indent = '    ';
-  sources = '{}';
+  sources = '{};';
   modules.forEach(function (module) {
     if (module.noflo && module.noflo.loader) {
       var loaderPath = path.resolve(options.baseDir, module.base, module.noflo.loader);
@@ -72,7 +72,7 @@ var serialize = function(modules, options, callback) {
           language = 'coffeescript';
         }
         var fullName = module.name ? module.name + '/' + component.name : component.name;
-        sources.push(indent + '"' + fullName + '": ' + JSON.stringify({
+        sources.push('  "' + fullName + '": ' + JSON.stringify({
           language: language,
           source: source
         }));

--- a/src/build_loader.js
+++ b/src/build_loader.js
@@ -23,9 +23,9 @@ var filterDependencies = function(modules, options, callback) {
   }
 };
 
-var serialize = function(modules, options) {
+var serialize = function(modules, options, callback) {
   var loaders = [];
-  var lines = [];
+  var components = [];
   var indent = '    ';
   modules.forEach(function (module) {
     if (module.noflo && module.noflo.loader) {
@@ -36,16 +36,16 @@ var serialize = function(modules, options) {
       return;
     }
     module.components.forEach(function (component) {
-      var fullname = module.name ? module.name + "/" + component.name : component.name;
+      var moduleName = module.name ? '"' + module.name + '"' : 'null';
       var componentPath = path.resolve(options.baseDir, component.path);
-      lines.push(indent + "'" + fullname + "': require(" + JSON.stringify(componentPath) + ")");
+      components.push("  loader.registerComponent(" + moduleName + ', "' + component.name + '", require(' + JSON.stringify(componentPath) + '))');
     });
   });
   var contents = {
-    components: "{\n" + (lines.join(',\n')) + "\n  };",
+    components: components.join(',\n'),
     loaders: "[\n" + (loaders.join(',\n')) + "\n  ];"
   };
-  return contents;
+  callback(null, contents);
 };
 
 exports.discover = function (options, callback) {
@@ -58,8 +58,7 @@ exports.discover = function (options, callback) {
       if (err) {
         return callback(err);
       }
-      var contents = serialize(modules, options);
-      callback(err, contents);
+      serialize(modules, options, callback);
     });
   });
   return;

--- a/templates/componentloader.js
+++ b/templates/componentloader.js
@@ -11,7 +11,7 @@ var registerCustomLoaders = function (loader, loaders, callback) {
   });
 };
 
-var sources = <%= sources %>;
+var sources = <%= sources %>
 
 exports.setSource = function (loader, packageId, name, source, language, callback) {
   var implementation;

--- a/templates/componentloader.js
+++ b/templates/componentloader.js
@@ -91,22 +91,8 @@ exports.getSource = function (loader, name, callback) {
 };
 
 exports.register = function (loader, callback) {
-  var components = <%= components %>
   var loaders = <%= loaders %>
-  var names = Object.keys(components);
-
-  names.forEach(function (fullname) {
-    var mod = components[fullname];
-    var tok = fullname.split('/');
-    if (tok.length == 2) {
-      var modulename = tok[0];
-      var componentname = tok[1];
-      loader.registerComponent(modulename, componentname, mod);
-    } else {
-      loader.registerComponent(null, fullname, mod);
-    }
-  });
-
+<%= components %>
   if (!loaders.length) {
     return callback();
   }

--- a/templates/componentloader.js
+++ b/templates/componentloader.js
@@ -11,7 +11,7 @@ var registerCustomLoaders = function (loader, loaders, callback) {
   });
 };
 
-var sources = {};
+var sources = <%= sources %>;
 
 exports.setSource = function (loader, packageId, name, source, language, callback) {
   var implementation;

--- a/templates/componentloader.js
+++ b/templates/componentloader.js
@@ -11,8 +11,11 @@ var registerCustomLoaders = function (loader, loaders, callback) {
   });
 };
 
+var sources = {};
+
 exports.setSource = function (loader, packageId, name, source, language, callback) {
   var implementation;
+  var originalSource = source;
   // Transpiling
   if (language === 'coffeescript') {
     if (!window.CoffeeScript) {
@@ -48,6 +51,12 @@ exports.setSource = function (loader, packageId, name, source, language, callbac
     return callback(new Error('Provided source failed to create a runnable component'));
   }
 
+  var fullName = packageId + '/' + name;
+  sources[fullName] = {
+    language: language,
+    source: originalSource
+  };
+
   loader.registerComponent(packageId, name, implementation, callback);
 };
 
@@ -64,6 +73,10 @@ exports.getSource = function (loader, name, callback) {
   if (loader.isGraph(component)) {
     componentData.code = JSON.stringify(component, null, 2);
     componentData.language = 'json';
+    return callback(null, componentData);
+  } else if (sources[name]) {
+    componentData.code = sources[name].source;
+    componentData.language = sources[name].language;
     return callback(null, componentData);
   } else if (typeof component === 'function') {
     componentData.code = component.toString();


### PR DESCRIPTION
When a project is built with `debug: true`, this makes original non-transpiled component sources to be returned with `getSource`.

Fixes #19