### PR TITLE
NoFlo 1.0.0 compat (ES6->ES5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,13 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-es2015": "^6.24.1",
     "bluebird": "^3.4.0",
     "clone": "^2.1.0",
     "coffee-loader": "^0.9.0",
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^2.0.2",
     "fbp-loader": "^0.1.1",
     "noflo-component-loader": "^0.1.2",
     "webpack": "^3.0.0"

--- a/spec/fixtures/package.json
+++ b/spec/fixtures/package.json
@@ -13,7 +13,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "noflo": "0.x >= 0.8",
+    "noflo": "^1.0.0",
     "noflo-math": "^0.2.0",
     "noflo-core": "^0.4.0",
     "noflo-objects": "^0.3.0",

--- a/tasks/noflo_browser.js
+++ b/tasks/noflo_browser.js
@@ -26,9 +26,27 @@ module.exports = function(grunt) {
         module: {
           rules: [
             {
+              test: /noflo([\\]+|\/)lib([\\]+|\/)(.*)\.js$|noflo([\\]+|\/)components([\\]+|\/)(.*)\.js$|fbp-graph([\\]+|\/)lib([\\]+|\/)(.*)\.js$/,
+              use: [
+                {
+                  loader: 'babel-loader',
+                  options: {
+                    presets: ['es2015']
+                  }
+                }
+              ]
+            },
+            {
               test: /\.coffee$/,
               use: [
-                "coffee-loader"
+                {
+                  loader: 'coffee-loader',
+                  options: {
+                    transpile: {
+                      presets: ['es2015']
+                    }
+                  }
+                }
               ]
             },
             {
@@ -44,7 +62,9 @@ module.exports = function(grunt) {
         },
         entry: null,
         target: 'web',
-        externals: {},
+        externals: {
+          temp: 'commonjs temp'
+        },
         plugins: []
       },
       // Modules that should be completely ignored


### PR DESCRIPTION
Adds babel to the build process to produce browser bundles that work in older browsers, like PhantomJS